### PR TITLE
Fixed logging changes for nullable dates

### DIFF
--- a/src/Event/AuditableListener.php
+++ b/src/Event/AuditableListener.php
@@ -181,7 +181,7 @@ class AuditableListener
 
                 if ($type instanceof DateTimeType || $type instanceof DateTimeTzType) {
                     $valueBefore = $valueBefore === null ? null : $valueBefore->format(self::DATETIME_WITH_TIMEZONE_FORMAT);
-                    $valueAfter  = $valueBefore === null ? null : $valueAfter->format(self::DATETIME_WITH_TIMEZONE_FORMAT);
+                    $valueAfter  = $valueAfter === null ? null : $valueAfter->format(self::DATETIME_WITH_TIMEZONE_FORMAT);
                 } elseif ($type instanceof Type) {
                     $platform    = $this->entityManager->getConnection()->getDatabasePlatform();
                     $valueBefore = $type->convertToDatabaseValue($valueBefore, $platform);


### PR DESCRIPTION
This PR fixes the case when date-time field in the entity changes to/from null value. In such a case `AuditableListener` checks the "before" value when processing "after" one